### PR TITLE
feat: DEVOPS-1446 evm-api-xbridge endpoint for testnet

### DIFF
--- a/bridge-validators/infra/config-leader.toml
+++ b/bridge-validators/infra/config-leader.toml
@@ -21,7 +21,7 @@ chain_gateway_address = "0x72B9B59e48779A8b64554A3e2bC8b5297A04c68a"
 # Zilliqa Testnet
 [[chain_configs]]
 chain_gateway_block_deployed = 6542681
-rpc_url = "https://dev-api.zilliqa.com"
+rpc_url = "https://evm-api-xbridge.testnet.zilliqa.com"
 chain_gateway_address = "0x10917A34FE60eE8364a401a6b1d3adaf80D84eb6"
 block_instant_finality = true
 legacy_gas_estimation = true

--- a/bridge-validators/infra/config.toml
+++ b/bridge-validators/infra/config.toml
@@ -26,7 +26,7 @@ chain_gateway_address = "0x72B9B59e48779A8b64554A3e2bC8b5297A04c68a"
 # Zilliqa Testnet
 [[chain_configs]]
 chain_gateway_block_deployed = 6542681
-rpc_url = "https://dev-api.zilliqa.com"
+rpc_url = "https://evm-api-xbridge.testnet.zilliqa.com"
 chain_gateway_address = "0x10917A34FE60eE8364a401a6b1d3adaf80D84eb6"
 block_instant_finality = true
 legacy_gas_estimation = true


### PR DESCRIPTION
Testnet endpoint updated to own node https://evm-api-xbridge.testnet.zilliqa.com (seedpub-2).